### PR TITLE
feat/link model with pages

### DIFF
--- a/src/features/auth/model/AuthErrorModal.tsx
+++ b/src/features/auth/model/AuthErrorModal.tsx
@@ -1,0 +1,62 @@
+import { useState } from 'react';
+import { Modal, Button, Typography, Space } from 'antd';
+import { ExclamationCircleOutlined, ReloadOutlined } from '@ant-design/icons';
+import type { AuthErrorState } from './useAuthError';
+
+const { Text } = Typography;
+
+interface AuthErrorModalProps {
+  errorState: AuthErrorState | null;
+  onClose: () => void;
+}
+
+export const AuthErrorModal = ({
+  errorState,
+  onClose,
+}: AuthErrorModalProps) => {
+  const [retrying, setRetrying] = useState(false);
+
+  const handleRetry = async () => {
+    if (!errorState?.retry) return;
+    setRetrying(true);
+    try {
+      await errorState.retry();
+      onClose(); // !если retry прошёл успешно то модалка закрывается
+    } catch {
+      // ошибка остается в errorState через handleError в родителе
+    } finally {
+      setRetrying(false);
+    }
+  };
+
+  return (
+    <Modal
+      open={!!errorState}
+      onCancel={onClose}
+      title={
+        <Space>
+          <ExclamationCircleOutlined style={{ color: '#ff4d4f' }} />
+          <span>Произошла ошибка</span>
+        </Space>
+      }
+      footer={[
+        <Button key="cancel" onClick={onClose}>
+          Закрыть
+        </Button>,
+        <Button
+          key="retry"
+          type="primary"
+          icon={<ReloadOutlined />}
+          loading={retrying}
+          onClick={handleRetry}
+        >
+          Повторить
+        </Button>,
+      ]}
+      centered
+      maskClosable={false}
+    >
+      <Text type="danger">{errorState?.message}</Text>
+    </Modal>
+  );
+};

--- a/src/features/auth/model/useAuthError.ts
+++ b/src/features/auth/model/useAuthError.ts
@@ -1,0 +1,25 @@
+import { useState, useCallback } from 'react';
+
+export interface AuthErrorState {
+  message: string;
+  retry: (() => Promise<void>) | null;
+}
+
+export const useAuthError = () => {
+  const [errorState, setErrorState] = useState<AuthErrorState | null>(null);
+
+  const handleError = useCallback(
+    (error: unknown, retry: () => Promise<void>) => {
+      const message =
+        error instanceof Error ? error.message : 'Неизвестная ошибка';
+      setErrorState({ message, retry });
+    },
+    [],
+  );
+
+  const clearError = useCallback(() => {
+    setErrorState(null);
+  }, []);
+
+  return { errorState, handleError, clearError };
+};

--- a/src/pages/auth/login/ui/LoginPage.tsx
+++ b/src/pages/auth/login/ui/LoginPage.tsx
@@ -6,9 +6,22 @@ import logo from '../../../../../public/logo.png';
 
 import { routePaths } from '@/shared/config/routePaths.ts';
 import { login } from '@/features/auth/model/login';
+import { useAuthError } from '@/features/auth/model/useAuthError';
+import { AuthErrorModal } from '@/features/auth/model/AuthErrorModal';
 
 export const LoginPage = () => {
   const navigate = useNavigate();
+  const { errorState, handleError, clearError } = useAuthError();
+
+  const performLogin = async (values: {
+    email: string;
+    password: string;
+    remember: boolean;
+  }) => {
+    const user = await login(values.email, values.password);
+    console.log('Успешный вход:', user);
+    navigate(routePaths.projects);
+  };
 
   const onFinish = async (values: {
     email: string;
@@ -16,12 +29,9 @@ export const LoginPage = () => {
     remember: boolean;
   }) => {
     try {
-      const user = await login(values.email, values.password);
-      console.log('Успешный вход:', user);
-      navigate(routePaths.projects);
+      await performLogin(values);
     } catch (error) {
-      console.error('Ошибка входа:', error);
-      // добавить уведомление
+      handleError(error, () => performLogin(values));
     }
   };
 
@@ -75,6 +85,8 @@ export const LoginPage = () => {
           </div>
         </Form>
       </Card>
+
+      <AuthErrorModal errorState={errorState} onClose={clearError} />
     </div>
   );
 };

--- a/src/pages/auth/login/ui/LoginPage.tsx
+++ b/src/pages/auth/login/ui/LoginPage.tsx
@@ -3,18 +3,26 @@ import { UserOutlined, LockOutlined } from '@ant-design/icons';
 import { useNavigate } from 'react-router-dom';
 import '../../AuthPage.css';
 import logo from '../../../../../public/logo.png';
+
 import { routePaths } from '@/shared/config/routePaths.ts';
+import { login } from '@/features/auth/model/login';
 
 export const LoginPage = () => {
   const navigate = useNavigate();
 
-  const onFinish = (values: {
-    username: string;
+  const onFinish = async (values: {
+    email: string;
     password: string;
     remember: boolean;
   }) => {
-    console.log(values);
-    navigate(routePaths.projects);
+    try {
+      const user = await login(values.email, values.password);
+      console.log('Успешный вход:', user);
+      navigate(routePaths.projects);
+    } catch (error) {
+      console.error('Ошибка входа:', error);
+      // добавить уведомление
+    }
   };
 
   return (
@@ -30,8 +38,8 @@ export const LoginPage = () => {
           size="large"
         >
           <Form.Item
-            name="username"
-            rules={[{ required: true, message: 'Пожалуйста, введите логин!' }]}
+            name="email"
+            rules={[{ required: true, message: 'Пожалуйста, введите email!' }]}
           >
             <Input prefix={<UserOutlined />} placeholder="Логин" />
           </Form.Item>

--- a/src/pages/auth/register/ui/RegisterPage.tsx
+++ b/src/pages/auth/register/ui/RegisterPage.tsx
@@ -2,17 +2,25 @@ import { Button, Card, Form, Input } from 'antd';
 import { useNavigate } from 'react-router-dom';
 import { UserOutlined, MailOutlined, LockOutlined } from '@ant-design/icons';
 
+import { register } from '@/features/auth/model/register';
+
 export const RegisterPage = () => {
   const navigate = useNavigate();
 
-  const onFinish = (values: {
+  const onFinish = async (values: {
     email: string;
-    username: string;
+    name: string;
     password: string;
     confirm: string;
   }) => {
-    console.log(values);
-    navigate('/projects');
+    try {
+      const user = await register(values.name, values.email, values.password);
+      console.log('Успешная регистрация:', user);
+      navigate('/projects');
+    } catch (error) {
+      console.error('Ошибка регистрации:', error);
+      // добавить уведомление
+    }
   };
 
   return (
@@ -42,8 +50,8 @@ export const RegisterPage = () => {
           </Form.Item>
 
           <Form.Item
-            name="username"
-            label="Логин"
+            name="name"
+            label="логин"
             rules={[{ required: true, message: 'Введите логин!' }]}
           >
             <Input prefix={<UserOutlined />} placeholder="Логин" />

--- a/src/pages/auth/register/ui/RegisterPage.tsx
+++ b/src/pages/auth/register/ui/RegisterPage.tsx
@@ -3,9 +3,23 @@ import { useNavigate } from 'react-router-dom';
 import { UserOutlined, MailOutlined, LockOutlined } from '@ant-design/icons';
 
 import { register } from '@/features/auth/model/register';
+import { useAuthError } from '@/features/auth/model/useAuthError';
+import { AuthErrorModal } from '@/features/auth/model/AuthErrorModal';
 
 export const RegisterPage = () => {
   const navigate = useNavigate();
+  const { errorState, handleError, clearError } = useAuthError();
+
+  const performRegister = async (values: {
+    email: string;
+    name: string;
+    password: string;
+    confirm: string;
+  }) => {
+    const user = await register(values.name, values.email, values.password);
+    console.log('Успешная регистрация:', user);
+    navigate('/projects');
+  };
 
   const onFinish = async (values: {
     email: string;
@@ -14,12 +28,9 @@ export const RegisterPage = () => {
     confirm: string;
   }) => {
     try {
-      const user = await register(values.name, values.email, values.password);
-      console.log('Успешная регистрация:', user);
-      navigate('/projects');
+      await performRegister(values);
     } catch (error) {
-      console.error('Ошибка регистрации:', error);
-      // добавить уведомление
+      handleError(error, () => performRegister(values));
     }
   };
 
@@ -42,7 +53,7 @@ export const RegisterPage = () => {
               {
                 type: 'email',
                 required: true,
-                message: 'Введите корректны Email!',
+                message: 'Введите корректный Email!',
               },
             ]}
           >
@@ -51,7 +62,7 @@ export const RegisterPage = () => {
 
           <Form.Item
             name="name"
-            label="логин"
+            label="Логин"
             rules={[{ required: true, message: 'Введите логин!' }]}
           >
             <Input prefix={<UserOutlined />} placeholder="Логин" />
@@ -100,6 +111,8 @@ export const RegisterPage = () => {
           </div>
         </Form>
       </Card>
+
+      <AuthErrorModal errorState={errorState} onClose={clearError} />
     </div>
   );
 };

--- a/src/pages/profile/ui/ProfilePage.tsx
+++ b/src/pages/profile/ui/ProfilePage.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Button, Avatar, Typography, Divider } from 'antd';
+import { Button, Avatar, Typography, Divider, Spin } from 'antd';
 import {
   UserOutlined,
   LogoutOutlined,
@@ -8,24 +8,65 @@ import {
   CalendarOutlined,
 } from '@ant-design/icons';
 import './ProfilePage.css';
+
 import { routePaths } from '@/shared/config/routePaths';
+import { getMe } from '@/features/auth/model/getMe';
+import { logout } from '@/features/auth/model/logout';
+import type { User } from '@/features/auth/model/types';
 
 const { Title, Text } = Typography;
 
 export const ProfilePage = () => {
   const navigate = useNavigate();
+  const [user, setUser] = useState<User | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
 
-  // Временные данные пользователя
-  const user = {
-    name: 'Алексей Иванов',
-    email: 'alexey.ivanov@example.com',
-    registeredAt: '15 октября 2023',
-  };
+  useEffect(() => {
+    const fetchUser = async () => {
+      try {
+        const userData = await getMe();
+        setUser(userData);
+      } catch (error) {
+        console.error('Ошибка загрузки профиля:', error);
+        // что тут должен показать ui ? ошибку ?
+      } finally {
+        setIsLoading(false);
+      }
+    };
 
-  const handleLogout = () => {
-    localStorage.removeItem('accessToken');
+    fetchUser();
+  }, []);
+
+  const handleLogout = async () => {
+    await logout();
     navigate(routePaths.login);
   };
+
+  if (isLoading) {
+    return (
+      <div className="profileLayout">
+        <div
+          className="profileCard"
+          style={{ textAlign: 'center', padding: '40px' }}
+        >
+          <Spin size="large" />
+        </div>
+      </div>
+    );
+  }
+
+  if (!user) {
+    return (
+      <div className="profileLayout">
+        <div
+          className="profileCard"
+          style={{ textAlign: 'center', padding: '40px' }}
+        >
+          <Text type="secondary">Не удалось загрузить профиль</Text>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="profileLayout">
@@ -47,7 +88,7 @@ export const ProfilePage = () => {
 
         <div className="profileInfoRow">
           <CalendarOutlined style={{ color: '#8c8c8c', marginRight: 8 }} />
-          <Text type="secondary">На платформе с {user.registeredAt}</Text>
+          <Text type="secondary">На платформе с {user.created_at}</Text>
         </div>
 
         <Divider />

--- a/src/shared/api/mock/auth.mock.ts
+++ b/src/shared/api/mock/auth.mock.ts
@@ -1,6 +1,6 @@
 import type { User } from '@/shared/api/generated/data-contracts';
 
-// fake USER !!!
+// fake USERS !!!
 const fakeUsers: (User & { password: string })[] = [
   {
     id: '550e8400-e29b-41d4-a716-446655440000',
@@ -12,6 +12,7 @@ const fakeUsers: (User & { password: string })[] = [
 ];
 
 let nextId = 2;
+let currentUserId: string | null = null;
 
 const delay = <T>(data: T, ms = 400): Promise<T> =>
   new Promise((res) => setTimeout(() => res(data), ms));
@@ -23,10 +24,16 @@ export const mockAuthApi = {
       (u) => u.email === email && u.password === password,
     );
     if (!user) {
-      throw new Error('Invalid credentials');
+      throw new Error('Неверный email или пароль');
     }
+
+    currentUserId = user.id;
+
     return {
-      data: { access: 'mock-access-token', message: 'Успешный вход в систему' },
+      data: {
+        access: 'mock-access-token',
+        message: 'Успешный вход в систему',
+      },
     };
   },
 
@@ -40,8 +47,17 @@ export const mockAuthApi = {
     password: string;
   }) {
     await delay(null);
+
+    if (!email.includes('@')) {
+      throw new Error('Некорректный формат email');
+    }
+
     if (fakeUsers.find((u) => u.email === email)) {
-      throw new Error('Email already exists');
+      throw new Error('Пользователь с таким email уже существует');
+    }
+
+    if (password.length < 8) {
+      throw new Error('Пароль должен быть не менее 8 символов');
     }
 
     const newUser: User & { password: string } = {
@@ -51,7 +67,10 @@ export const mockAuthApi = {
       password,
       created_at: new Date().toISOString(),
     };
+
     fakeUsers.push(newUser);
+
+    currentUserId = newUser.id;
 
     return {
       data: {
@@ -63,13 +82,26 @@ export const mockAuthApi = {
 
   async getAuth() {
     await delay(null);
-    const { password, ...user } = fakeUsers[0];
+
+    const user = currentUserId
+      ? fakeUsers.find((u) => u.id === currentUserId)
+      : fakeUsers[0];
+
+    if (!user) {
+      throw new Error('Пользователь не найден');
+    }
+
+    const { password, ...userWithoutPassword } = user;
     void password;
-    return { data: user as User };
+
+    return { data: userWithoutPassword as User };
   },
 
   async logoutCreate() {
     await delay(null);
+
+    currentUserId = null;
+
     return {
       data: { message: 'Успешный выход из системы', status: 'success' },
     };
@@ -82,8 +114,17 @@ export const mockAuthApi = {
   }) {
     void _data;
     await delay(null);
+
+    if (_data.new_password !== _data.confirm_password) {
+      throw new Error('Пароли не совпадают');
+    }
+
+    if (_data.new_password.length < 8) {
+      throw new Error('Новый пароль должен быть не менее 8 символов');
+    }
+
     return {
-      data: { message: 'Password changed successfully', status: 'success' },
+      data: { message: 'Пароль успешно изменен', status: 'success' },
     };
   },
 };


### PR DESCRIPTION
страницы логина, регистрации и профиля используют функции из auth/model 
логин , вход , выход и отображение профиля мокового пользователя работает 

update:
1) папка model:
useAuthError.ts : добавлен хук управления ошибками, возвращает значения для модального окна ошибки
AuthErrorModal.tsx : модальное окно ошибки, (содержит кнопку повторить, кнопка повторить вызывает функцию из хука и повторяет запрос )

2) 
в LoginPage и RegisterPage подключены хук и модалка 

выглядит так 
<img width="1177" height="555" alt="image" src="https://github.com/user-attachments/assets/1ffe50b7-d3c9-4a45-a8cb-665f8dee20ee" />
